### PR TITLE
Expose 'crypt_volume_key_get'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,10 @@
 !devicetypes
 !test
 
-!**.go
-!**.txt
 !**.md
+!**.txt
+!**.mod
+!**.go
 !**.c
 !**.h
 

--- a/device.go
+++ b/device.go
@@ -237,19 +237,19 @@ func (device *Device) VolumeKeyGet(keyslot int, passphrase string) ([]byte, int,
 	defer C.free(unsafe.Pointer(cPassphrase))
 
 	cVKSize := C.crypt_get_volume_key_size(device.cryptDevice)
-	cVKPointer := C.crypt_safe_alloc(C.ulong(cVKSize))
-	if cVKPointer == nil {
-		return []byte{}, 0, &Error{functionName: "crypt_safe_alloc"}
+	cVKSizePointer := C.malloc(C.size_t(cVKSize))
+	if cVKSizePointer == nil {
+		return []byte{}, 0, &Error{functionName: "malloc"}
 	}
-	defer C.crypt_safe_free(cVKPointer)
+	defer C.free(cVKSizePointer)
 
 	err := C.crypt_volume_key_get(
 		device.cryptDevice, C.int(keyslot),
-		(*C.char)(cVKPointer), (*C.size_t)(unsafe.Pointer(&cVKSize)),
+		(*C.char)(cVKSizePointer), (*C.size_t)(unsafe.Pointer(&cVKSize)),
 		cPassphrase, C.size_t(len(passphrase)),
 	)
 	if err < 0 {
 		return []byte{}, 0, &Error{functionName: "crypt_volume_key_get", code: int(err)}
 	}
-	return C.GoBytes(unsafe.Pointer(cVKPointer), C.int(cVKSize)), int(err), nil
+	return C.GoBytes(unsafe.Pointer(cVKSizePointer), C.int(cVKSize)), int(err), nil
 }

--- a/device_test.go
+++ b/device_test.go
@@ -155,3 +155,53 @@ func Test_Device_KeyslotChangeByPassphrase_Fails_If_Device_Has_No_Type(test *tes
 	testWrapper.AssertError(err)
 	testWrapper.AssertErrorCodeEquals(err, -22)
 }
+
+func Test_Device_VolumeKeyGet(test *testing.T) {
+	volumeKeySize := 512 / 8
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	err = device.Format(LUKS2{SectorSize: 512}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: volumeKeySize})
+	testWrapper.AssertNoError(err)
+
+	defer device.Free()
+
+	err = device.KeyslotAddByVolumeKey(0, "", "firstPassphrase")
+	testWrapper.AssertNoError(err)
+
+	err = device.KeyslotAddByPassphrase(1, "firstPassphrase", "secondPassphrase")
+	testWrapper.AssertNoError(err)
+
+	volumeKey, volumeKeySlot, err := device.VolumeKeyGet(CRYPT_ANY_SLOT, "secondPassphrase")
+	testWrapper.AssertNoError(err)
+
+	if len(volumeKey) != volumeKeySize {
+		test.Errorf("Invalid volume key size length: %d", len(volumeKey))
+	} else if volumeKeySlot != 1 {
+		test.Errorf("Volume key slot should have been 1, but was: %d", volumeKeySlot)
+	}
+}
+
+func Test_Device_VolumeKeyGet_Fails_If_Wrong_Passphrase(test *testing.T) {
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	err = device.Format(LUKS2{SectorSize: 512}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: 512 / 8})
+	testWrapper.AssertNoError(err)
+
+	defer device.Free()
+
+	err = device.KeyslotAddByVolumeKey(0, "", "testPassphrase")
+	testWrapper.AssertNoError(err)
+
+	volumeKey, volumeKeySlot, err := device.VolumeKeyGet(CRYPT_ANY_SLOT, "secondTestPassphrase")
+	testWrapper.AssertError(err)
+
+	if len(volumeKey) != 0 {
+		test.Errorf("Invalid volume key size length: %d", len(volumeKey))
+	} else if volumeKeySlot != 0 {
+		test.Errorf("Volume key slot should have been zero, but was: %d", volumeKeySlot)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module cryptsetup
+
+go 1.16


### PR DESCRIPTION
`Device.VolumeKeyGet` returns the following values:

- The slice of bytes, having the volume key.
- The unlocked key slot number, which will be `0` if there's an error.
- A possible error. Will be `nil` if there's no error.

The upstream C version requires us to provide a buffer for the volume key because C doesn't allow multiple return values. Sure, a `struct` could've been used by them, but C also encourages using straight `int` or another numeric type to represent possible returned errors.

I didn't want to harken back to this lower-level, explicit buffer-passing style. Your original idea of returning `[]byte` works beautifully. But you're absolutely right, having the unlocked key slot number could definitely be useful, and it's what the upstream API provides.

Let me know your thoughts!