### PR TITLE
device: add abilty to pass parameters to Load()

### DIFF
--- a/luks1_test.go
+++ b/luks1_test.go
@@ -44,7 +44,7 @@ func Test_LUKS1_Load_ActivateByPassphrase_Deactivate(test *testing.T) {
 
 	device, err = Init(DevicePath)
 	testWrapper.AssertNoError(err)
-	err = device.Load()
+	err = device.Load(nil)
 	testWrapper.AssertNoError(err)
 
 	err = device.ActivateByPassphrase(DeviceName, 0, "testPassphrase", CRYPT_ACTIVATE_READONLY)

--- a/luks2_test.go
+++ b/luks2_test.go
@@ -140,7 +140,7 @@ func Test_LUKS2_Load_ActivateByPassphrase_Deactivate(test *testing.T) {
 
 	device, err = Init(DevicePath)
 	testWrapper.AssertNoError(err)
-	err = device.Load()
+	err = device.Load(nil)
 	testWrapper.AssertNoError(err)
 
 	err = device.ActivateByPassphrase(DeviceName, 0, "testPassphrase", CRYPT_ACTIVATE_READONLY)


### PR DESCRIPTION
I just used the same DeviceType mechanism here, since the API for crypt_load()
takes the same params structs based on device type.

This is necessary for e.g. VERITY device types where you have to specify
the root hash in order to correctly load them.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>