### PR TITLE
Add Resize and GetDeviceName method

### DIFF
--- a/device.go
+++ b/device.go
@@ -245,11 +245,15 @@ func (device *Device) KeyslotChangeByPassphrase(currentKeyslot int, newKeyslot i
 }
 
 // ActivateByPassphrase activates a device by using a passphrase from a specific keyslot.
+// If deviceName is empty only check passphrase.
 // Returns nil on success, or an error otherwise.
 // C equivalent: crypt_activate_by_passphrase
 func (device *Device) ActivateByPassphrase(deviceName string, keyslot int, passphrase string, flags int) error {
-	cryptDeviceName := C.CString(deviceName)
-	defer C.free(unsafe.Pointer(cryptDeviceName))
+	var cryptDeviceName *C.char = nil
+	if len(deviceName) > 0 {
+		cryptDeviceName = C.CString(deviceName)
+		defer C.free(unsafe.Pointer(cryptDeviceName))
+	}
 
 	cPassphrase := C.CString(passphrase)
 	defer C.free(unsafe.Pointer(cPassphrase))
@@ -263,11 +267,15 @@ func (device *Device) ActivateByPassphrase(deviceName string, keyslot int, passp
 }
 
 // ActivateByVolumeKey activates a device by using a volume key.
+// If deviceName is empty only check passphrase.
 // Returns nil on success, or an error otherwise.
 // C equivalent: crypt_activate_by_volume_key
 func (device *Device) ActivateByVolumeKey(deviceName string, volumeKey string, volumeKeySize int, flags int) error {
-	cryptDeviceName := C.CString(deviceName)
-	defer C.free(unsafe.Pointer(cryptDeviceName))
+	var cryptDeviceName *C.char = nil
+	if len(deviceName) > 0 {
+		cryptDeviceName = C.CString(deviceName)
+		defer C.free(unsafe.Pointer(cryptDeviceName))
+	}
 
 	var cVolumeKey *C.char = nil
 	if len(volumeKey) > 0 {

--- a/device.go
+++ b/device.go
@@ -337,6 +337,13 @@ func (device *Device) VolumeKeyGet(keyslot int, passphrase string) ([]byte, int,
 	return C.GoBytes(unsafe.Pointer(cVKSizePointer), C.int(cVKSize)), int(err), nil
 }
 
+// GetDeviceName gets the path to the underlying device.
+// C equivalent: crypt_get_device_name
+func (device *Device) GetDeviceName() string {
+	res := C.crypt_get_device_name(device.cryptDevice)
+	return C.GoString(res)
+}
+
 // GetUUID gets the device's UUID.
 // C equivalent: crypt_get_uuid
 func (device *Device) GetUUID() string {

--- a/device.go
+++ b/device.go
@@ -136,6 +136,22 @@ func (device *Device) Wipe(devicePath string, pattern int, offset, length uint64
 	return nil
 }
 
+// Resize the crypt device.
+// Set newSize to 0 to use all of the underlying device size
+// Returns nil on success, or an error otherwise.
+// C equivalent: crypt_resize
+func (device *Device) Resize(name string, newSize uint64) error {
+	cryptDeviceName := C.CString(name)
+	defer C.free(unsafe.Pointer(cryptDeviceName))
+
+	err := C.crypt_resize(device.cryptDevice, cryptDeviceName, C.uint64_t(newSize))
+	if err < 0 {
+		return &Error{functionName: "crypt_resize", code: int(err)}
+	}
+
+	return nil
+}
+
 // Load loads crypt device parameters from the device type parameters if it is
 // specified, otherwise it loads the device from the on-disk header.
 // Returns nil on success, or an error otherwise.

--- a/device_test.go
+++ b/device_test.go
@@ -214,6 +214,21 @@ func Test_Device_VolumeKeyGet_Fails_If_Wrong_Passphrase(test *testing.T) {
 	}
 }
 
+func Test_Device_GetDeviceName(test *testing.T) {
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	defer device.Free()
+	err = device.Format(LUKS2{SectorSize: 512}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: 512 / 8})
+	testWrapper.AssertNoError(err)
+
+	devicePath := device.GetDeviceName()
+	if devicePath != DevicePath {
+		test.Errorf("Returned the wrong device path: got %s, expected %s", devicePath, DevicePath)
+	}
+}
+
 func Test_Device_GetUUID(test *testing.T) {
 	testWrapper := TestWrapper{test}
 

--- a/luks1_test.go
+++ b/luks1_test.go
@@ -222,3 +222,34 @@ func Test_LUKS1_KeyslotChangeByPassphrase(test *testing.T) {
 
 	device.Free()
 }
+
+func Test_LUKS1_Resize(test *testing.T) {
+	resizeDiskPath := "testResizeDevice"
+	setup(resizeDiskPath)
+	defer teardown(resizeDiskPath)
+
+	testWrapper := TestWrapper{test}
+
+	genericParams := GenericParams{
+		Cipher:        "aes",
+		CipherMode:    "xts-plain64",
+		VolumeKey:     generateKey(512/8, test),
+		VolumeKeySize: 512 / 8,
+	}
+
+	device, err := Init(resizeDiskPath)
+	testWrapper.AssertNoError(err)
+	defer device.Free()
+
+	err = device.Format(LUKS1{Hash: "sha256"}, genericParams)
+	testWrapper.AssertNoError(err)
+
+	err = device.ActivateByVolumeKey(DeviceName, genericParams.VolumeKey, genericParams.VolumeKeySize, CRYPT_ACTIVATE_READONLY)
+	testWrapper.AssertNoError(err)
+	defer device.Deactivate(DeviceName)
+
+	resize(resizeDiskPath)
+
+	err = device.Resize(DeviceName, 0)
+	testWrapper.AssertNoError(err)
+}

--- a/main_test.go
+++ b/main_test.go
@@ -66,12 +66,16 @@ func generateKey(length int, test *testing.T) string {
 	return string(bytes[:])
 }
 
-func setup() {
-	exec.Command("/bin/dd", "if=/dev/zero", fmt.Sprintf("of=%s", DevicePath), "bs=64M", "count=1").Run()
+func setup(devicePath string) {
+	exec.Command("/bin/dd", "if=/dev/zero", fmt.Sprintf("of=%s", devicePath), "bs=64M", "count=1").Run()
 }
 
-func teardown() {
-	exec.Command("/bin/rm", "-f", DevicePath).Run()
+func teardown(devicePath string) {
+	exec.Command("/bin/rm", "-f", devicePath).Run()
+}
+
+func resize(devicePath string) {
+	exec.Command("/bin/dd", "if=/dev/zero", fmt.Sprintf("of=%s", devicePath), "bs=32M", "count=1", "oflag=append", "conv=notrunc").Run()
 }
 
 func TestMain(m *testing.M) {
@@ -80,8 +84,8 @@ func TestMain(m *testing.M) {
 		os.Exit(1)
 	}
 
-	setup()
+	setup(DevicePath)
 	result := m.Run()
-	teardown()
+	teardown(DevicePath)
 	os.Exit(result)
 }

--- a/plain_test.go
+++ b/plain_test.go
@@ -137,3 +137,27 @@ func Test_Plain_KeyslotChangeByPassphrase_Should_Not_Be_Supported(test *testing.
 
 	device.Free()
 }
+
+func Test_Plain_Resize(test *testing.T) {
+	resizeDiskPath := "testResizeDevice"
+	setup(resizeDiskPath)
+	defer teardown(resizeDiskPath)
+
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(resizeDiskPath)
+	testWrapper.AssertNoError(err)
+	defer device.Free()
+
+	err = device.Format(Plain{Hash: "sha256"}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: 512 / 8})
+	testWrapper.AssertNoError(err)
+
+	err = device.ActivateByPassphrase(DeviceName, 0, PassKey, CRYPT_ACTIVATE_READONLY)
+	testWrapper.AssertNoError(err)
+	defer device.Deactivate(DeviceName)
+
+	resize(resizeDiskPath)
+
+	err = device.Resize(DeviceName, 0)
+	testWrapper.AssertNoError(err)
+}


### PR DESCRIPTION
Adds CGo bindings for the [`crypt_resize()`](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-actions.html#ga168bcd5097cdf64774540fdeaacefbc0) and [`crypt_get_device_name()`](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-devstat.html#gafe63a9c1eb9b0a07da1ac3ae915cee64) functions.

To keep the tests clean I have slightly modified the `setup()` and `teardown()` functions so one may reuse them throughout the tests.

I have also added the option to call the activate functions (`ActivateByPassphrase()` and `ActivateByVolumeKey()`) with an empty device name to provide the passphrase/volumekey checking functionality.
For example, this is used by `cryptsetup` during `cryptsetup resize` to activate the keyring key of an already active device: https://gitlab.com/cryptsetup/cryptsetup/-/blob/v2.4.3/src/cryptsetup.c#L815