### PR TITLE
fix: correct type passed to crypt_volume_key_get

### DIFF
--- a/device.go
+++ b/device.go
@@ -319,8 +319,8 @@ func (device *Device) VolumeKeyGet(keyslot int, passphrase string) ([]byte, int,
 	cPassphrase := C.CString(passphrase)
 	defer C.free(unsafe.Pointer(cPassphrase))
 
-	cVKSize := C.crypt_get_volume_key_size(device.cryptDevice)
-	cVKSizePointer := C.malloc(C.size_t(cVKSize))
+	cVKSize := C.size_t(C.crypt_get_volume_key_size(device.cryptDevice))
+	cVKSizePointer := C.malloc(cVKSize)
 	if cVKSizePointer == nil {
 		return []byte{}, 0, &Error{functionName: "malloc"}
 	}
@@ -328,7 +328,7 @@ func (device *Device) VolumeKeyGet(keyslot int, passphrase string) ([]byte, int,
 
 	err := C.crypt_volume_key_get(
 		device.cryptDevice, C.int(keyslot),
-		(*C.char)(cVKSizePointer), (*C.size_t)(unsafe.Pointer(&cVKSize)),
+		(*C.char)(cVKSizePointer), &cVKSize,
 		cPassphrase, C.size_t(len(passphrase)),
 	)
 	if err < 0 {


### PR DESCRIPTION
Thanks for the great Go module!

I've run into a memory issue detected by `checkptr`.  I don't have a small code snippet handy to reproduce... but the relevant output I'm seeing is:

```
$ go test -race ./...
fatal error: checkptr: converted pointer straddles multiple allocations

goroutine 331 [running]:
runtime.throw({0x1adb785?, 0x177e2ac?})
        /usr/local/go/src/runtime/panic.go:1047 +0x5d fp=0xc000bbd530 sp=0xc000bbd500 pc=0x44e79d
runtime.checkptrAlignment(0xc0003b49e0?, 0xc000bbd580?, 0x424ea7?)
        /usr/local/go/src/runtime/checkptr.go:26 +0x6c fp=0xc000bbd550 sp=0xc000bbd530 pc=0x41dc2c
github.com/martinjungblut/go-cryptsetup.(*Device).VolumeKeyGet.func4(0xc0022737a0, 0xffffffffffffffff, 0xc000bbd4a0?, 0x177d5b2?, 0x0?, {0x0?, 0x0})
        /home/adam/go/pkg/mod/github.com/martinjungblut/go-cryptsetup@v0.0.0-20220520180014-fd0874fd07a6/device.go:331 +0x7a fp=0xc000bbd5c0 sp=0xc000bbd550 pc=0x177e79a
github.com/martinjungblut/go-cryptsetup.(*Device).VolumeKeyGet(0x0?, 0x0?, {0x0, 0x0})
        /home/adam/go/pkg/mod/github.com/martinjungblut/go-cryptsetup@v0.0.0-20220520180014-fd0874fd07a6/device.go:333 +0x18c fp=0xc000bbd708 sp=0xc000bbd5c0 pc=0x177e2ac
...
```

I believe this patch fixes the issue by ensuring `cVKSize` is a `C.size_t` rather than `C.int`. Since `C.crypt_volume_key_get` takes a pointer to `cVKSize`, the width of the value must match.