### PR TITLE
Add bindings for cryptsetup token functions

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           go-version: '1.20'
       - run: dnf install -y gcc pkg-config cryptsetup-libs cryptsetup-devel
-      - run: go test -v ./...
+      - run: go test -tags="cryptsetup2.4" -v ./...
   ubuntu-20-04-go-1-18:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -16,8 +16,8 @@ jobs:
   ubuntu-20-04-go-1-18:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.18'
       - run: sudo apt-get update
@@ -26,20 +26,10 @@ jobs:
   ubuntu-20-04-go-1-17:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
         with:
           go-version: '1.17'
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y libcryptsetup12 libcryptsetup-dev
-      - run: sudo go test -v ./...
-  ubuntu-18-04-go-1-16:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: '1.16'
       - run: sudo apt-get update
       - run: sudo apt-get install -y libcryptsetup12 libcryptsetup-dev
       - run: sudo go test -v ./...

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,6 +1,18 @@
 name: run-tests
 on: [push]
 jobs:
+  fedora-38-go-1-20:
+    runs-on: ubuntu-latest
+    container:
+      image: fedora:38
+      options: --privileged
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.20'
+      - run: dnf install -y gcc pkg-config cryptsetup-libs cryptsetup-devel
+      - run: go test -v ./...
   ubuntu-20-04-go-1-18:
     runs-on: ubuntu-20.04
     steps:

--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ These bindings have been tested using libcryptsetup >= 2.0.
 
 GitHub Actions runs the test suite using the following version combinations:
 
-| Ubuntu version | Go version | libcryptsetup version |
-|----------------|------------|-----------------------|
-| 20.04 LTS      | 1.18       | 2.2.2                 |
-| 20.04 LTS      | 1.17       | 2.2.2                 |
-| 18.04 LTS      | 1.16       | 2.0.2                 |
+| OS               | Go version | libcryptsetup version |
+|------------------|------------|-----------------------|
+| Fedora 38        | 1.20       | 2.6.1                 |
+| Ubuntu 20.04 LTS | 1.18       | 2.2.2                 |
+| Ubuntu 20.04 LTS | 1.17       | 2.2.2                 |
 
 Locally, I also test on Fedora, using the latest version of libcryptsetup and Go.
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ This project is a _pure Go interface for libcryptsetup_, providing a clean and p
 
 These bindings have been tested using libcryptsetup >= 2.0.
 
+Since the latest LTS release of Ubuntu (22.04) currently ships libcryptsetup v2.2.2, functions that require a newer version are gated behind build tags.
+To use functions requiring libcryptsetup v2.4, build your application with `-tags="cryptsetup2.4"`.
+
 GitHub Actions runs the test suite using the following version combinations:
 
 | OS               | Go version | libcryptsetup version |

--- a/const.go
+++ b/const.go
@@ -176,3 +176,21 @@ const (
 	/**< Compatibility only, do not use (Gutmann method) */
 	CRYPT_WIPE_SPECIAL = C.CRYPT_WIPE_SPECIAL
 )
+
+// TokenInfo is an enum type for token information.
+type TokenInfo int
+
+const (
+	// token is invalid.
+	CRYPT_TOKEN_INVALID = C.CRYPT_TOKEN_INVALID
+	// token is empty (free).
+	CRYPT_TOKEN_INACTIVE = C.CRYPT_TOKEN_INACTIVE
+	// active internal token with driver.
+	CRYPT_TOKEN_INTERNAL = C.CRYPT_TOKEN_INTERNAL
+	// active internal token (reserved name) with missing token driver.
+	CRYPT_TOKEN_INTERNAL_UNKNOWN = C.CRYPT_TOKEN_INTERNAL_UNKNOWN
+	// active external (user defined) token with driver
+	CRYPT_TOKEN_EXTERNAL = C.CRYPT_TOKEN_EXTERNAL
+	// active external (user defined) token with missing token driver
+	CRYPT_TOKEN_EXTERNAL_UNKNOWN = C.CRYPT_TOKEN_EXTERNAL_UNKNOWN
+)

--- a/device.go
+++ b/device.go
@@ -289,40 +289,6 @@ func (device *Device) ActivateByToken(deviceName string, token int, usrptr strin
 	return nil
 }
 
-// ActivateByTokenPin activates a device or checks key using a token with PIN.
-// C equivalent: crypt_activate_by_token_pin
-func (device *Device) ActivateByTokenPin(deviceName string, tokenType string, token int, pin string, pinSize int, usrptr string, flags int) error {
-	var cryptDeviceName *C.char = nil
-	if len(deviceName) > 0 {
-		cryptDeviceName = C.CString(deviceName)
-		defer C.free(unsafe.Pointer(cryptDeviceName))
-	}
-
-	var cTokenType *C.char = nil
-	if len(tokenType) > 0 {
-		cTokenType = C.CString(tokenType)
-		defer C.free(unsafe.Pointer(cTokenType))
-	}
-
-	var cPin *C.char = nil
-	if len(pin) > 0 {
-		cPin = C.CString(pin)
-		defer C.free(unsafe.Pointer(cPin))
-	}
-
-	var cUsrptr *C.char = nil
-	if len(usrptr) > 0 {
-		cUsrptr = C.CString(usrptr)
-		defer C.free(unsafe.Pointer(cUsrptr))
-	}
-
-	err := C.crypt_activate_by_token_pin(device.cryptDevice, cryptDeviceName, cTokenType, C.int(token), cPin, C.size_t(pinSize), unsafe.Pointer(cUsrptr), C.uint32_t(flags))
-	if err < 0 {
-		return &Error{functionName: "crypt_activate_by_token_pin", code: int(err)}
-	}
-	return nil
-}
-
 // ActivateByVolumeKey activates a device by using a volume key.
 // If deviceName is empty only check passphrase.
 // Returns nil on success, or an error otherwise.

--- a/device.go
+++ b/device.go
@@ -63,19 +63,6 @@ func (device *Device) Dump() int {
 	return int(C.crypt_dump(device.cryptDevice))
 }
 
-// DumpJSON returns JSON-formatted information about a LUKS2 device.
-// C equivalent: crypt_dump_json
-func (device *Device) DumpJSON() (string, error) {
-	cStr := C.CString("")
-	defer C.free(unsafe.Pointer(cStr))
-
-	// crypt_dump_json does not support flags currently, but they are reserved for future use.
-	if res := C.crypt_dump_json(device.cryptDevice, &cStr, C.uint32_t(0)); res != 0 {
-		return "", &Error{functionName: "crypt_dump_json", code: int(res)}
-	}
-	return C.GoString(cStr), nil
-}
-
 // Type returns the device's type as a string.
 // Returns an empty string if the information is not available.
 func (device *Device) Type() string {

--- a/device.go
+++ b/device.go
@@ -473,3 +473,15 @@ func (device *Device) TokenIsAssigned(token int, keyslot int) error {
 	}
 	return nil
 }
+
+// TokenStatus gets info for specific token.
+// On success returns the token type as string.
+// C equivalent: crypt_token_status
+func (device *Device) TokenStatus(token int) (string, TokenInfo) {
+	cStr := C.CString("")
+	defer C.free(unsafe.Pointer(cStr))
+
+	res := C.crypt_token_status(device.cryptDevice, C.int(token), &cStr)
+	tokenInfo := TokenInfo(res)
+	return C.GoString(cStr), tokenInfo
+}

--- a/device.go
+++ b/device.go
@@ -392,3 +392,43 @@ func (device *Device) TokenJSONSet(token int, json string) (int, error) {
 	}
 	return int(res), nil
 }
+
+// TokenAssignKeyslot assigns a token to particular keyslot. (There can be more keyslots assigned to one token id.)
+// Use CRYPT_ANY_TOKEN to assign all tokens to keyslot.
+// Use CRYPT_ANY SLOT to assign all active keyslots to token.
+// C equivalent: crypt_token_assign_keyslot
+func (device *Device) TokenAssignKeyslot(token int, keyslot int) error {
+	res := C.crypt_token_assign_keyslot(device.cryptDevice, C.int(token), C.int(keyslot))
+
+	// libcryptsetup returns the token ID on success
+	// In case of CRYPT_ANY_TOKEN, the token ID is -1,
+	// so we need to make sure the response is actually an error instead of a token ID
+	resAnyToken := token == CRYPT_ANY_TOKEN && int(res) == token
+	if res < 0 && !resAnyToken {
+		return &Error{functionName: "crypt_token_assign_keyslot", code: int(res)}
+	}
+	return nil
+}
+
+// TokenUnassignKeyslot unassigns a token from particular keyslot.
+// There can be more keyslots assigned to one token id.
+// Use CRYPT_ANY_TOKEN to unassign all tokens from keyslot.
+// Use CRYPT_ANY SLOT to unassign all active keyslots from token.
+// C equivalent: crypt_token_unassign_keyslot
+func (device *Device) TokenUnassignKeyslot(token int, keyslot int) error {
+	res := C.crypt_token_unassign_keyslot(device.cryptDevice, C.int(token), C.int(keyslot))
+	resAnyToken := token == CRYPT_ANY_TOKEN && int(res) == token
+	if res < 0 && !resAnyToken {
+		return &Error{functionName: "crypt_token_assign_keyslot", code: int(res)}
+	}
+	return nil
+}
+
+// TokenIsAssigned gets info about token assignment to particular keyslot.
+// C equivalent: crypt_token_is_assigned
+func (device *Device) TokenIsAssigned(token int, keyslot int) error {
+	if res := C.crypt_token_is_assigned(device.cryptDevice, C.int(token), C.int(keyslot)); res < 0 {
+		return &Error{functionName: "crypt_token_is_assigned", code: int(res)}
+	}
+	return nil
+}

--- a/device_test.go
+++ b/device_test.go
@@ -262,44 +262,6 @@ func Test_Device_GetUUID(test *testing.T) {
 	}
 }
 
-func Test_Device_DumpJSON(test *testing.T) {
-	testWrapper := TestWrapper{test}
-
-	device, err := Init(DevicePath)
-	testWrapper.AssertNoError(err)
-	defer device.Free()
-
-	// Format the device using aes-xts-plain64
-	cipher := "aes"
-	cipherMode := "xts-plain64"
-	err = device.Format(LUKS2{SectorSize: 512}, GenericParams{Cipher: cipher, CipherMode: cipherMode, VolumeKeySize: 512 / 8})
-	testWrapper.AssertNoError(err)
-
-	// Dump device info
-	jsonInfo, err := device.DumpJSON()
-	testWrapper.AssertNoError(err)
-
-	// Check that the cipher and cipher mode are correct
-	type segment struct {
-		Encryption string `json:"encryption"`
-	}
-	var info struct {
-		Segments map[string]segment `json:"segments"`
-	}
-
-	err = json.Unmarshal([]byte(jsonInfo), &info)
-	testWrapper.AssertNoError(err)
-
-	if len(info.Segments) != 1 {
-		test.Errorf("Expected one segment, got %d", len(info.Segments))
-	}
-	for _, segment := range info.Segments {
-		if segment.Encryption != cipher+"-"+cipherMode {
-			test.Errorf("Expected encryption to be %s-%s, got %s", cipher, cipherMode, segment.Encryption)
-		}
-	}
-}
-
 func Test_Device_TokenJSON(test *testing.T) {
 	testWrapper := TestWrapper{test}
 

--- a/device_test.go
+++ b/device_test.go
@@ -284,8 +284,9 @@ func Test_Device_TokenJSON(test *testing.T) {
 		Data     string `json:"data"`
 	}
 
+	tokenType := "unit-test"
 	newToken := tokenStruct{
-		Type:     "unit-test",
+		Type:     tokenType,
 		Keyslots: []int{},
 		Data:     "foo",
 	}
@@ -310,6 +311,15 @@ func Test_Device_TokenJSON(test *testing.T) {
 	}
 	if tokenOut.Data != newToken.Data {
 		test.Errorf("Expected token data to be %s, got %s", newToken.Data, tokenOut.Data)
+	}
+
+	gotTokenType, status := device.TokenStatus(tokenID)
+	if gotTokenType != tokenType {
+		test.Errorf("Expected token type to be %s, got %s", tokenType, gotTokenType)
+	}
+	// Since we created a custom token without handler, that should be the status of the token
+	if status != CRYPT_TOKEN_EXTERNAL_UNKNOWN {
+		test.Errorf("Expected token status to be %d, got %d", CRYPT_TOKEN_EXTERNAL_UNKNOWN, status)
 	}
 }
 

--- a/futures.go
+++ b/futures.go
@@ -1,3 +1,5 @@
+//go:build cryptsetup2.4
+
 package cryptsetup
 
 // #cgo pkg-config: libcryptsetup
@@ -8,6 +10,19 @@ import "C"
 import (
 	"unsafe"
 )
+
+// DumpJSON returns JSON-formatted information about a LUKS2 device.
+// C equivalent: crypt_dump_json
+func (device *Device) DumpJSON() (string, error) {
+	cStr := C.CString("")
+	defer C.free(unsafe.Pointer(cStr))
+
+	// crypt_dump_json does not support flags currently, but they are reserved for future use.
+	if res := C.crypt_dump_json(device.cryptDevice, &cStr, C.uint32_t(0)); res != 0 {
+		return "", &Error{functionName: "crypt_dump_json", code: int(res)}
+	}
+	return C.GoString(cStr), nil
+}
 
 // TokenExternalDisable disables external token handlers (plugins) support.
 // If disabled, it cannot be enabled again.

--- a/futures.go
+++ b/futures.go
@@ -24,6 +24,40 @@ func (device *Device) DumpJSON() (string, error) {
 	return C.GoString(cStr), nil
 }
 
+// ActivateByTokenPin activates a device or checks key using a token with PIN.
+// C equivalent: crypt_activate_by_token_pin
+func (device *Device) ActivateByTokenPin(deviceName string, tokenType string, token int, pin string, pinSize int, usrptr string, flags int) error {
+	var cryptDeviceName *C.char = nil
+	if len(deviceName) > 0 {
+		cryptDeviceName = C.CString(deviceName)
+		defer C.free(unsafe.Pointer(cryptDeviceName))
+	}
+
+	var cTokenType *C.char = nil
+	if len(tokenType) > 0 {
+		cTokenType = C.CString(tokenType)
+		defer C.free(unsafe.Pointer(cTokenType))
+	}
+
+	var cPin *C.char = nil
+	if len(pin) > 0 {
+		cPin = C.CString(pin)
+		defer C.free(unsafe.Pointer(cPin))
+	}
+
+	var cUsrptr *C.char = nil
+	if len(usrptr) > 0 {
+		cUsrptr = C.CString(usrptr)
+		defer C.free(unsafe.Pointer(cUsrptr))
+	}
+
+	err := C.crypt_activate_by_token_pin(device.cryptDevice, cryptDeviceName, cTokenType, C.int(token), cPin, C.size_t(pinSize), unsafe.Pointer(cUsrptr), C.uint32_t(flags))
+	if err < 0 {
+		return &Error{functionName: "crypt_activate_by_token_pin", code: int(err)}
+	}
+	return nil
+}
+
 // TokenExternalDisable disables external token handlers (plugins) support.
 // If disabled, it cannot be enabled again.
 // C equivalent: crypt_token_external_disable

--- a/futures_test.go
+++ b/futures_test.go
@@ -1,0 +1,46 @@
+//go:build cryptsetup2.4
+
+package cryptsetup
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func Test_Device_DumpJSON(test *testing.T) {
+	testWrapper := TestWrapper{test}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	defer device.Free()
+
+	// Format the device using aes-xts-plain64
+	cipher := "aes"
+	cipherMode := "xts-plain64"
+	err = device.Format(LUKS2{SectorSize: 512}, GenericParams{Cipher: cipher, CipherMode: cipherMode, VolumeKeySize: 512 / 8})
+	testWrapper.AssertNoError(err)
+
+	// Dump device info
+	jsonInfo, err := device.DumpJSON()
+	testWrapper.AssertNoError(err)
+
+	// Check that the cipher and cipher mode are correct
+	type segment struct {
+		Encryption string `json:"encryption"`
+	}
+	var info struct {
+		Segments map[string]segment `json:"segments"`
+	}
+
+	err = json.Unmarshal([]byte(jsonInfo), &info)
+	testWrapper.AssertNoError(err)
+
+	if len(info.Segments) != 1 {
+		test.Errorf("Expected one segment, got %d", len(info.Segments))
+	}
+	for _, segment := range info.Segments {
+		if segment.Encryption != cipher+"-"+cipherMode {
+			test.Errorf("Expected encryption to be %s-%s, got %s", cipher, cipherMode, segment.Encryption)
+		}
+	}
+}

--- a/luks1_test.go
+++ b/luks1_test.go
@@ -244,11 +244,11 @@ func Test_LUKS1_Resize(test *testing.T) {
 	err = device.Format(LUKS1{Hash: "sha256"}, genericParams)
 	testWrapper.AssertNoError(err)
 
+	resize(resizeDiskPath)
+
 	err = device.ActivateByVolumeKey(DeviceName, genericParams.VolumeKey, genericParams.VolumeKeySize, CRYPT_ACTIVATE_READONLY)
 	testWrapper.AssertNoError(err)
 	defer device.Deactivate(DeviceName)
-
-	resize(resizeDiskPath)
 
 	err = device.Resize(DeviceName, 0)
 	testWrapper.AssertNoError(err)

--- a/luks2.go
+++ b/luks2.go
@@ -199,3 +199,8 @@ func (luks2 LUKS2) Unmanaged() (unsafe.Pointer, func()) {
 
 	return unsafe.Pointer(&cParams), deallocate
 }
+
+// TokenParamsLUKS2KeyRing defines LUKS2 keyring token parameters.
+type TokenParamsLUKS2Keyring struct {
+	KeyDescription string
+}

--- a/luks2_test.go
+++ b/luks2_test.go
@@ -397,3 +397,48 @@ func Test_LUKS2_Resize(test *testing.T) {
 	err = device.Resize(DeviceName, 0)
 	testWrapper.AssertNoError(err)
 }
+
+func Test_LUKS2_ActivateByToken(test *testing.T) {
+	testWrapper := TestWrapper{test}
+	luks2 := LUKS2{SectorSize: 512}
+
+	genericParams := GenericParams{
+		Cipher:        "aes",
+		CipherMode:    "xts-plain64",
+		VolumeKey:     generateKey(512/8, test),
+		VolumeKeySize: 512 / 8,
+	}
+
+	device, err := Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	err = device.Format(luks2, genericParams)
+	testWrapper.AssertNoError(err)
+
+	err = device.KeyslotAddByVolumeKey(0, "", "testPassphrase")
+	testWrapper.AssertNoError(err)
+	device.Free()
+
+	device, err = Init(DevicePath)
+	testWrapper.AssertNoError(err)
+	err = device.Load(nil)
+	testWrapper.AssertNoError(err)
+
+	tokenParams := TokenParamsLUKS2Keyring{KeyDescription: "testKeyDescription"}
+	tokenID, err := device.TokenLUKS2KeyRingSet(CRYPT_ANY_TOKEN, tokenParams)
+	testWrapper.AssertNoError(err)
+
+	err = device.TokenAssignKeyslot(CRYPT_ANY_TOKEN, CRYPT_ANY_SLOT)
+	testWrapper.AssertNoError(err)
+
+	// Assert that the token was set
+	token, err := device.TokenLUKS2KeyRingGet(tokenID)
+	testWrapper.AssertNoError(err)
+	if token.KeyDescription != tokenParams.KeyDescription {
+		test.Errorf("Expected token key description to be %s, but got %s", tokenParams.KeyDescription, token.KeyDescription)
+	}
+
+	// Activate by token
+	err = device.ActivateByToken(DeviceName, tokenID, "unitTest", CRYPT_ACTIVATE_READONLY)
+	// Since we don't have any real tokens in the keyring we expect an error
+	testWrapper.AssertError(err)
+}

--- a/luks2_test.go
+++ b/luks2_test.go
@@ -388,11 +388,11 @@ func Test_LUKS2_Resize(test *testing.T) {
 	err = device.Format(LUKS2{SectorSize: 512}, genericParams)
 	testWrapper.AssertNoError(err)
 
+	resize(resizeDiskPath)
+
 	err = device.ActivateByVolumeKey(DeviceName, genericParams.VolumeKey, genericParams.VolumeKeySize, CRYPT_ACTIVATE_READONLY)
 	testWrapper.AssertNoError(err)
 	defer device.Deactivate(DeviceName)
-
-	resize(resizeDiskPath)
 
 	err = device.Resize(DeviceName, 0)
 	testWrapper.AssertNoError(err)

--- a/plain_test.go
+++ b/plain_test.go
@@ -152,11 +152,11 @@ func Test_Plain_Resize(test *testing.T) {
 	err = device.Format(Plain{Hash: "sha256"}, GenericParams{Cipher: "aes", CipherMode: "xts-plain64", VolumeKeySize: 512 / 8})
 	testWrapper.AssertNoError(err)
 
+	resize(resizeDiskPath)
+
 	err = device.ActivateByPassphrase(DeviceName, 0, PassKey, CRYPT_ACTIVATE_READONLY)
 	testWrapper.AssertNoError(err)
 	defer device.Deactivate(DeviceName)
-
-	resize(resizeDiskPath)
 
 	err = device.Resize(DeviceName, 0)
 	testWrapper.AssertNoError(err)

--- a/token.go
+++ b/token.go
@@ -1,0 +1,34 @@
+package cryptsetup
+
+// #cgo pkg-config: libcryptsetup
+// #include <libcryptsetup.h>
+// #include <stdlib.h>
+import "C"
+
+import (
+	"unsafe"
+)
+
+// TokenExternalDisable disables external token handlers (plugins) support.
+// If disabled, it cannot be enabled again.
+// C equivalent: crypt_token_external_disable
+func TokenExternalDisable() {
+	C.crypt_token_external_disable()
+}
+
+// TokenExternalPath reports configured path where library searches for external token handlers.
+// C equivalent: crypt_token_external_path
+func TokenExternalPath() string {
+	res := C.crypt_token_external_path()
+	return C.GoString(res)
+}
+
+// TokenMax gets the number of tokens supported for device type.
+// Returns token count or negative errno otherwise if device doesn't not support tokens
+// C equivalent: crypt_token_max
+func TokenMax(deviceType DeviceType) int {
+	cType := C.CString(deviceType.Name())
+	defer C.free(unsafe.Pointer(cType))
+
+	return int(C.crypt_token_max(cType))
+}


### PR DESCRIPTION
I tried adding bindings for most of the cryptsetup token functions defined in the [cryptsetup token API spec](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-tokens.html).

The PR is split into multiple commits which each come with their own (small) description of changes.
I hope that makes this larger PR a bit more readable.

### New functions

The list of functions include:
* `crypt_token_assign_keyslot`
* `crypt_token_external_disable`
* `crypt_token_external_path`
* `crypt_token_is_assigned`
* `crypt_token_json_get`
* `crypt_token_json_set`
* `crypt_token_luks2_keyring_get`
* `crypt_token_luks2_keyring_set`
* `crypt_token_max`
* `crypt_token_status`
* `crypt_token_unassign_keyslot`

As well as the `crypt_token_info` enumeration type.

I have also added bindings for [`crypt_dump_json`](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-devstat.html#ga69a849166ff7e3c59478e6373677c631), as it closely relates to the token functions.

I have not not yet added bindings for [`crypt_token_register`](https://mbroz.fedorapeople.org/libcryptsetup_API/group__crypt-tokens.html#gabcb5bcfb0fc4a0886a81ccfcbfdb63e6), as I'm not currently making use of that function and implementing the required types would probably take a a decent amount more effort and testing.

### CI

Since some of the functions I added bindings for only exist in cryptsetup >=v2.4, I added a job to the CI that runs the tests on Fedora 38 (which ships cryptsetup v2.6).
To avoid breaking compatibility with distributions that don't ship any of the newer cryptsetup versions, I also went ahead and put the relevant functions behind a build tag (`cryptsetupv2.4` to be precise).
That way consumers of the library can update the go-library without having to upgrade the cryptsetup library.

I also removed the CI job that used Ubuntu 18.04, since GitHub no longer offers runners for that distribution.
If running tests on Ubuntu 18.04 is still something you would like to keep, I can probably just add a containerized job with Ubuntu 18.04 to keep the test functional.