### PR TITLE
Output error message for codes

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,6 +1,9 @@
 package cryptsetup
 
-import "fmt"
+import (
+	"fmt"
+	"syscall"
+)
 
 // Error holds the name and the return value of a libcryptsetup function that was executed with an error.
 type Error struct {
@@ -9,7 +12,11 @@ type Error struct {
 }
 
 func (e *Error) Error() string {
-	return fmt.Sprintf("libcryptsetup function '%s' returned error with code '%d'.", e.functionName, e.code)
+	code := e.code
+	if code < 0 {
+		code = -code
+	}
+	return fmt.Sprintf("libcryptsetup function '%s' returned error with code '%d': %s.", e.functionName, e.code, syscall.Errno(code).Error())
 }
 
 // Code returns the error code returned by a libcryptsetup function.


### PR DESCRIPTION
Just a small improvement to the output of errors generated by this library.
Instead of just printing the code, this PR allows for printing the associated message alongside the code.

For example, deactivating a non active device will output:
```
libcryptsetup function 'crypt_deactivate' returned error with code '-19': no such device.
```
instead of just
```sh
libcryptsetup function 'crypt_deactivate' returned error with code '-19'.
```

Feel free to just close this PR if you feel like this is not necessary.